### PR TITLE
Require Numpy 1.20 or later

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,8 +85,8 @@ with open("README.rst", "r") as f:
 setup(
     name = "axographio",
     version = VERSION,
-    setup_requires   = ['numpy', 'cython>=0.19'],   # needed to build axographio
-    install_requires = ['numpy'],                   # needed to run axographio
+    setup_requires   = ['numpy>=1.20', 'cython>=0.19'],   # needed to build axographio
+    install_requires = ['numpy>=1.20'],                   # needed to run axographio
     packages = ['axographio', 'axographio.tests'],
     ext_modules = [
         Extension('axographio.extension', [


### PR DESCRIPTION
Numpy 1.20 introduced a backwards-incompatible change to its C API, such that wheels built with Numpy 1.20 are incompatible with installations running Numpy 1.19 or older. To avoid problems like issue #8 in the future, axographio will now require Numpy 1.20 or later.